### PR TITLE
Add basic CMake support for ps1transfer

### DIFF
--- a/ps1transfer/CMakeLists.txt
+++ b/ps1transfer/CMakeLists.txt
@@ -12,15 +12,15 @@ if(UNIX)
     find_package(LibFTDI1 REQUIRED)
 endif()
 
-add_executable(ps1transfer
+add_executable(${PROJECT_NAME}
     main.c
     lodepng.c
 )
 
 if(WIN32)
-    target_link_libraries(ps1transfer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ftd2xx.lib)
-    target_compile_definitions(ps1transfer PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ftd2xx.lib)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 elseif(UNIX)
-    target_include_directories(ps1transfer PRIVATE /usr/include/libftdi1/)
-    target_link_libraries(ps1transfer PRIVATE ftdi1)
+    target_include_directories(${PROJECT_NAME} PRIVATE /usr/include/libftdi1/)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ftdi1)
 endif()

--- a/ps1transfer/CMakeLists.txt
+++ b/ps1transfer/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.5)
+
+if(WIN32)
+    # Force building x86 on Windows since the FTDI libs are x86
+    set(CMAKE_GENERATOR_PLATFORM Win32 CACHE INTERNAL "")
+endif()
+
+project(ps1transfer C)
+
+if(UNIX)
+    # Linux users must install libftdi1 (Under Debian: sudo apt-get install libftdi1)
+    find_package(LibFTDI1 REQUIRED)
+endif()
+
+add_executable(ps1transfer
+    main.c
+    lodepng.c
+)
+
+if(WIN32)
+    target_link_libraries(ps1transfer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ftd2xx.lib)
+    target_compile_definitions(ps1transfer PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+elseif(UNIX)
+    target_include_directories(ps1transfer PRIVATE /usr/include/libftdi1/)
+    target_link_libraries(ps1transfer PRIVATE ftdi1)
+endif()

--- a/ps1transfer/main.c
+++ b/ps1transfer/main.c
@@ -14,7 +14,13 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#ifdef WIN32
+#include <io.h>
+#include <direct.h>
+#define chdir _chdir
+#else
 #include <unistd.h>
+#endif
 #include "lodepng.h"
 #include "crc.h"
 
@@ -456,7 +462,7 @@ pcdrvout:
 
 int main(int argc, char *argv[])
 {
-	int			x, y, w, h, i, ret, cmd = CMD_UNKNOWN;
+	int			x, y, w, h, i, cmd = CMD_UNKNOWN;
 	uint32_t	size = 0, adrs = 0x80010000, *ptr32;
 	uint16_t	*ptr16;
 	uint8_t		*data = NULL, *ptr;
@@ -472,6 +478,8 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 #else
+	int ret;
+
 	if ((ftdi = ftdi_new()) == 0)
 	{
 		fprintf(stderr, "ftdi_new failed\n");


### PR DESCRIPTION
Super basic CMakeLists.txt that builds ps1transfer for Windows and 'nix.  Have not tested on a Mac.